### PR TITLE
Update of `wannier.vim` and `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Vim 8.0+ recognizes plugins under `$HOME/.vim/pack/**/start`.
 Vim recognizes plugins for syntax highlighting under `$HOME/.vim/syntax` and `$HOME/.vim/ftdetect`.
 
 ```sh
-% https://github.com/KensukeKurita/wannier90vim.git
+% git clone https://github.com/KensukeKurita/wannier90vim.git
 % mkdir -p $HOME/.vim/syntax $HOME/.vim/ftdetect
 % cp ./syntax/wannier.vim             $HOME/.vim/syntax/wannier.vim
 % cp ./ftdetect/wannier-detect.vim    $HOME/.vim/ftdetect/wannier-detect.vim

--- a/README.md
+++ b/README.md
@@ -9,11 +9,23 @@ Please check the package when you see the source codes in this plugin.
 
 ## Install
 
-If there are not syntax and ftdetect directory under `./.vim/`, please make them.
+### For Vim 8.0+
+
+Vim 8.0+ recognizes plugins under `$HOME/.vim/pack/**/start`.
 
 ```sh
-cp ./syntax/wannier.vim             ~/.vim/syntax/wannier.vim
-cp ./ftdetect/wannier-detect.vim    ~/.vim/ftdetect/wannier-detect.vim
+% git clone https://github.com/KensukeKurita/wannier90vim.git $HOME/.vim/pack/**/start
+```
+
+### Old Vim
+
+Vim recognizes plugins for syntax highlighting under `$HOME/.vim/syntax` and `$HOME/.vim/ftdetect`.
+
+```sh
+% https://github.com/KensukeKurita/wannier90vim.git
+% mkdir -p $HOME/.vim/syntax $HOME/.vim/ftdetect
+% cp ./syntax/wannier.vim             $HOME/.vim/syntax/wannier.vim
+% cp ./ftdetect/wannier-detect.vim    $HOME/.vim/ftdetect/wannier-detect.vim
 ```
 
 ## About `param2vim.py`

--- a/syntax/wannier.vim
+++ b/syntax/wannier.vim
@@ -105,7 +105,7 @@ syntax keyword wanKey wannier_plot_scale
 syntax keyword wanKey wannier_plot_spinor_mode
 syntax keyword wanKey wannier_plot_spinor_phase
 syntax keyword wanKey bands_plot
-syntax match   wanKey '[kK]point_path'
+syntax match   wanKey '[kK]point_[pP]ath'
 syntax keyword wanKey nnkpts
 syntax keyword wanKey bands_num_points
 syntax keyword wanKey bands_plot_format


### PR DESCRIPTION
I'm sorry for bothering you by sending pull requests repeatedly.
I forgot to completely fix `wanKey`s in `wannier.vim` and to update installation commands written in `README.md` along with the standard package loading function in Vim 8.0+.
I have confirmed that there is no bug or error when I put clone this repository under the new package location of `$HOME/.vim/pack/hoge`.
Please try it and merge if there is also no problem in your environment.